### PR TITLE
feat: add confirm option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ await importLocalOrNpx("../create-typescript-app", {
 
 1. Local import `{ kind: "local", resolved: object }`: if importing the specifier with `await import()` and [`enhanced-resolve`](https://github.com/webpack/enhanced-resolve) succeeded
 2. npx import `{ kind: "npx", resolved: object }`: failing that, if importing the specifier with [`importNpx`](https://github.com/geelen/npx-import) succeeded
-3. Failure `{ kind: "failure", local: Error; npx: Error }`: if both of those failed
+3. Failure `{ kind: "failure", local: Error; npx: Error }`: if both of those failed or were canceled
 
 ```ts
 import { importLocalOrNpx } from "import-local-or-npx";


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #15
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/import-local-or-npx/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/import-local-or-npx/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds an optional `confirm` option that will be called before `npx` is run.

For example, using a [Clack confirmation prompt](https://github.com/bombshell-dev/clack/tree/d4444390e80057708cd91a67db8319493839b56b/packages/prompts):

```ts
const imported = await importLocalOrNpx(from, {
  confirm: async () => {
    const allowed = await prompts.confirm({
      message: `Ok to proceed?`,
    });

    if (allowed !== true) {
      return new Error("Installation canceled.");
    }
  },
});
```

💖 